### PR TITLE
Add Saffman kernel option to stokesLimit2D.

### DIFF
--- a/bin/inputfiles/data.main.Saffman2D
+++ b/bin/inputfiles/data.main.Saffman2D
@@ -1,0 +1,107 @@
+# Select the GPU to run fluam
+# In general it's better not to use this option
+# setDevice 0
+
+#Saffman mode is a modification of stokesLimit2D in which the kernel changes from:
+#	 R(k) = 1/(shearViscosity*k*k)*(I-k^k)	     #stokesLimit2D kernel
+#
+#      To:
+#
+#         R(k) = 1/(shearViscosity*k*(k+k_c*tanh(k*H)))*(I-k^k) #Saffman kernel
+#
+# Three options are available in Saffman mode:
+#       -saffmanCutOffWaveNumber [=0] cut off wave number in Saffman kernel (k_c).
+#	-saffmanLayerWidth [=0] width of the layer for the PBC correction in the Saffman kernel (H).
+#	-viscosityMeasureAmplitude [=0] amplitude of the sinusoidal shear flow
+#
+#If none of the parameters are present the code falls back to stokesLimit2D.
+#If saffmanLayerWidth is zero the PBC correction is not added (the tanh(k·H) term is taken as 1)
+
+
+# Chose scheme
+# Saffman mode must have stokesLimit2D to work
+
+stokesLimit2D
+
+saffmanCutOffWaveNumber 0.05
+saffmanLayerWidth 0
+viscosityMeasureAmplitude 0
+
+
+particles                               1
+
+# Default integrator is Forward-Euler, to
+# use predictor-corrector as in Eq. 34-35
+# in Delong et al. 2014 (doi:10.1063/1.4869866)
+# set the next variable to 1
+predictorCorrector                      0
+
+# Number of particles
+numberparticles                         1304
+
+# Set to zero if particle-particle interactions are ignored
+computeNonBondedForces                  0
+
+# Cutoff for the particle-particle interaction
+cutoff                                  22.4492409662
+# Give file with the bonded force between particles (see fluam/bin/inputfile/README)
+# bondedForces		harmonicTrap.dat
+# Maximum number of particles in the neighbor list
+maxNumberPartInCellNonBonded            20
+maxNumberPartInCell     	              20
+
+# Fluid density
+densfluid                               1.0
+# Shear viscosity
+shearviscosity                          1.0
+# Temperature in energy units (T -> k_B*T)
+temperature                             1.0
+hydrodynamicRadius                      1.0
+
+# Number of fluid cells in the directions x, y and z
+cells		                                160 160 1
+# Dimensions of the simulation box
+celldimension                           128 128 1
+
+
+# To give an initial configuration for the particles
+# set loadparticles to 1 and provide the file for initial configuration
+# and optionally a file for the initial velocities.
+# If no file is given the particles start in simple cubic lattice.
+loadparticles		                        0
+coordinates		                          /sibm/fbalboa/fluam/bin/blobsRandom.dat
+
+
+# Seed to feed the random number generator. If no one is given 
+# fluam takes one from the computer clock. 
+# seed			                            1
+
+# Number of relaxation steps during which fluam save no data 
+numstepsRelaxation	                    0
+# Number of steps (no counting numstepsRelaxation) 
+numsteps                                100
+# Save data every samplefreq steps 
+samplefreq                              2
+# Time step
+dt                                      0.2
+
+# Prefix for the output files. The directory where the data is saved
+# should exist before running fluam
+outputname                              ../data/run
+
+
+
+
+
+
+# Variables for HydroGrid:
+# Give first and last index of green particles,
+# the rest of particles are red
+greenParticles                          0 652
+# number of cells to compute concentration
+cellsHydroGrid                          100 100 
+# Do HydroGrid analysis every "sampleHydroGrid" steps
+sampleHydroGrid                         1
+# if savefreq > 0 HydroGrid prints data every savefreq steps and it restarts
+savefreq		                            0
+

--- a/src/createCellsQuasi2DGPU.cu
+++ b/src/createCellsQuasi2DGPU.cu
@@ -22,6 +22,10 @@
 
 
 bool createCellsQuasi2DGPU(){
+  //Raul added. Upload saffman variables to gpu
+  cutilSafeCall(cudaMemcpyToSymbol(saffmanCutOffWaveNumberGPU,&saffmanCutOffWaveNumber, sizeof(double)));
+  cutilSafeCall(cudaMemcpyToSymbol(saffmanLayerWidthGPU,&saffmanLayerWidth, sizeof(double)));
+
   cutilSafeCall(cudaMemcpyToSymbol(mxGPU,&mx,sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(myGPU,&my,sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(mzGPU,&mz,sizeof(int)));

--- a/src/fluid.h
+++ b/src/fluid.h
@@ -34,3 +34,7 @@ EXTERN_FLUID double pressurea2;
 EXTERN_FLUID double densityConst, dDensity, omega;
 EXTERN_FLUID int initfluid;
 //EXTERN_FLUID double concentration;
+//Raul added. Saffman cut off wave number for quasi2D kernel and viscosity measure for quasi2D run scheme.
+EXTERN_FLUID double saffmanCutOffWaveNumber;
+EXTERN_FLUID double viscosityMeasureAmplitude;
+EXTERN_FLUID double saffmanLayerWidth;

--- a/src/gpuVariables.cu
+++ b/src/gpuVariables.cu
@@ -26,6 +26,10 @@
 //DATA FOR EACH CELL: 26 INT + 10 DOUBLE = 144 B
 //DATA FOR EACH BOUNDARY: 1 INT + 34 DOUBLE = 140 B
 
+//Raul Added. GPU version of Saffman cut off
+__constant__ double saffmanCutOffWaveNumberGPU;
+__constant__ double saffmanLayerWidthGPU;
+
 typedef struct{
   int* vecino0GPU;
   int* vecino1GPU;

--- a/src/initializeFluidGPU.cu
+++ b/src/initializeFluidGPU.cu
@@ -29,8 +29,6 @@ bool initializeFluidGPU(){
   cutilSafeCall(cudaMemcpy(rycellGPU,cry,ncellst*sizeof(double),cudaMemcpyHostToDevice));
   cutilSafeCall(cudaMemcpy(rzcellGPU,crz,ncellst*sizeof(double),cudaMemcpyHostToDevice));
   
-
-  
   
   cout << "INITIALIZE FLUID GPU :          DONE" << endl;
 

--- a/src/loadDataMain.cu
+++ b/src/loadDataMain.cu
@@ -86,6 +86,10 @@ const string wsaveVTK="saveVTK";
 const string wbondedForces="bondedForces";
 const string wbondedForcesVersion="bondedForcesVersion";
 const string wcomputeNonBondedForces="computeNonBondedForces";
+//Raul added, a saffman cut off wave number is now a possible input for quasi2D, which will change the kernel to 1/(k*(k+kc)). Also added viscosity measure amplitude (amplitude of the sinusoidal perturbation). Also add layer width for PBC saffman correction
+const string wsaffmanCutOffWaveNumber="saffmanCutOffWaveNumber";
+const string wviscosityMeasureAmplitude="viscosityMeasureAmplitude";
+const string wsaffmanLayerWidth="saffmanLayerWidth";
 
 const string wGhost="ghost";
 //Other Fluid Variables
@@ -202,6 +206,10 @@ bool loadDataMain(int argc, char* argv[]){
   bondedForcesVersion=0;
   computeNonBondedForces=1;
   setVolumeParticle=0;
+  //Raul Added. Default value of saffman cut off, makes the code behave as normal. Also added viscosity measure amp
+  saffmanCutOffWaveNumber=0.0;
+  viscosityMeasureAmplitude = 0.0;
+  saffmanLayerWidth = 0.0;
   //DEFAULT PARAMETERS 
 
   //OTHER FLUID VARIABLES
@@ -318,6 +326,18 @@ bool loadDataMain(int argc, char* argv[]){
       fileinput >> setparticles;
     }
     //NEW_PARAMETER
+    //Raul added, processing of saffman cut off, layer width and viscosity measure input
+    else if(word==wsaffmanCutOffWaveNumber){
+      fileinput >> saffmanCutOffWaveNumber;
+    }
+    else if(word==wsaffmanLayerWidth){
+      fileinput >> saffmanLayerWidth;
+    }
+
+    else if(word==wviscosityMeasureAmplitude){
+      fileinput >> viscosityMeasureAmplitude;
+    }
+    
     else if(word==widentity_prefactor){
       fileinput >> identity_prefactor;
     }

--- a/src/runSchemeQuasi2D.cu
+++ b/src/runSchemeQuasi2D.cu
@@ -16,11 +16,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Fluam. If not, see <http://www.gnu.org/licenses/>.
-#include <thrust/transform.h>
-#include <thrust/functional.h>
-#include <thrust/iterator/zip_iterator.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/device_ptr.h>
 bool runSchemeQuasi2D(){
   int threadsPerBlock = 512;
   if((ncells/threadsPerBlock) < 512) threadsPerBlock = 256;

--- a/src/runSchemeQuasi2D.cu
+++ b/src/runSchemeQuasi2D.cu
@@ -210,10 +210,20 @@ bool runSchemeQuasi2D(){
       addStochasticVelocityRPYQuasi2D<<<numBlocks, threadsPerBlock>>>(vxZ,vyZ,dRand,1.0,0);
     }
     else if(stokesLimit2D){
-      // Compute deterministic fluid velocity
-      kernelUpdateVIncompressibleSpectral2D<<<numBlocks,threadsPerBlock>>>(vxZ,vyZ,vzZ,vxZ,vyZ,vzZ,pF); 
-      // Add stochastic velocity
-      addStochasticVelocitySpectral2D<<<numBlocks, threadsPerBlock>>>(vxZ,vyZ,dRand);
+      //Raul added, call Saffman kernels if Saffman mode is a Saffman cut off is provided.
+      if(saffmanCutOffWaveNumber != 0.0){
+	// Compute deterministic fluid velocity
+	kernelUpdateVIncompressibleSaffman2D<<<numBlocks,threadsPerBlock>>>(vxZ,vyZ,vzZ,vxZ,vyZ,vzZ,pF); 
+	// Add stochastic velocity
+	addStochasticVelocitySaffman2D<<<numBlocks, threadsPerBlock>>>(vxZ,vyZ,dRand);
+
+      }
+      else{
+	// Compute deterministic fluid velocity
+	kernelUpdateVIncompressibleSpectral2D<<<numBlocks,threadsPerBlock>>>(vxZ,vyZ,vzZ,vxZ,vyZ,vzZ,pF); 
+	// Add stochastic velocity
+	addStochasticVelocitySpectral2D<<<numBlocks, threadsPerBlock>>>(vxZ,vyZ,dRand);
+      }
     }
 
     // Transform velocity field to real space


### PR DESCRIPTION
Add a kernel in quasi2D to add a sinusoidal shear flow to all fluid cells.

The new kernel is:

     R(k) = 1/(shearViscosity*k*(k+k_c*tanh(k*H)))*(I-k^k)

Three new options are available in data.main:
    -saffmanCutOffWaveNumber [=0] cut off wave number in Saffman kernel (k_c).
    -saffmanLayerWidth [=0] width of the layer for the PBC correction in the Saffman kernel (H).
    -viscosityMeasureAmplitude [=0] amplitude of the sinusoidal shear flow

If none of the parameters are present the code falls back to stokesLimit2D.
If saffmanLayerWidth is zero the PBC correction is not added (the tanh(k·H) term is taken as 1)